### PR TITLE
Commit message after changes were done

### DIFF
--- a/plugins/uudecode.py
+++ b/plugins/uudecode.py
@@ -46,5 +46,6 @@ class UUDecode(plugintemplates.IMapiDAgentPlugin):
                 stream.Write(('\n'.join(uulines)+'\n').decode('uu'))
                 attach.SaveChanges(0)
             message.SetProps([SPropValue(PR_BODY, '\r\n'.join(body2))])
+            message.Commit(0)
             message.SaveChanges(0)
         return plugintemplates.MP_CONTINUE,


### PR DESCRIPTION
Without this function call the plugin would finish for with the message

Unable to commit message: 0x80070005

Message would stay in mailq since "Mailbox Temporarily Unavailable" has
been sent as answer. Although this error occured a message was delivered
to the mailbox.
