### PR TITLE
adapt to new socket path and add a compat switch

### DIFF
--- a/webapp/reset_webapp-settings.py
+++ b/webapp/reset_webapp-settings.py
@@ -9,7 +9,12 @@ def check_input():
             sys.exit('Usage: %s username' % sys.argv[0])
 
 def reset_settings():
-        s = OpenECSession(sys.argv[1], '', 'file:///var/run/zarafa')
+        socket = "file:///var/run/zarafad/server.sock"
+
+        if len(sys.argv) == 3 and sys.argv[2] == "compat":
+            socket = "file:///var/run/zarafa"
+
+        s = OpenECSession(sys.argv[1], '', socket)
         st = GetDefaultStore(s)
 
         PR_EC_WEBACCESS_SETTINGS_JSON = PROP_TAG(PT_STRING8, PR_EC_BASE+0x72)


### PR DESCRIPTION
calling this script now with second parameter "compat" restores old behaviour:

$ ./reset_webapp-settings.py foo compat

will connect to /var/run/zarafa

while

$ ./reset_webapp-settings.py foo

will connect to /var/run/zarafad/server.sock
